### PR TITLE
add write lock switch

### DIFF
--- a/include/spin_lock.h
+++ b/include/spin_lock.h
@@ -3,7 +3,6 @@
 #include <unistd.h>
 #include <atomic>
 #include <cstdint>
-#include <memory>
 #include "vrt_comm.h"
 
 namespace vrt {

--- a/include/test_vrt.cc
+++ b/include/test_vrt.cc
@@ -1,5 +1,4 @@
 #include <array>
-#include <iostream>
 #include <random>
 #include <string>
 
@@ -132,12 +131,6 @@ TEST(RandomTest, RandomTest) {
     EXPECT_EQ(value, std::to_string(i));
   }
 }
-
-// TEST(MTest, MTest) {
-//   while (true) {
-//     sleep(5);
-//   }
-// }
 
 GTEST_API_ int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
In read-only scenarios or scenarios with one write and multiple reads, there is no need to add write locks to the nodes. By adding template parameters to optimize these scenarios, performance can be improved.